### PR TITLE
Fix manifest merger failed attribute application@allowbackup

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.pwittchen.rxbattery.library">
 
-  <application
-      android:allowBackup="true"
-      android:supportsRtl="true">
+  <application>
 
   </application>
 


### PR DESCRIPTION
Library manifest should not set android:allowBackup to true.